### PR TITLE
Narrow the binary ignores to what they are for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,7 @@ Thumbs.db
 src/electron/dist/*.js
 .studio/*.user.json
 
-# Reverse-engineering spike reference material - NEVER commit (proprietary Microsoft binaries).
-# Covers the reference DLLs, the Windows Media Player archive and anything extracted from it.
+# Third-party binaries and archives - never commit.
 *.dll
 *.exe
 *.zip
-*.wmz
-mpvis.dll
-Windows Media Player.zip
-Windows Media Player/


### PR DESCRIPTION
## Summary

The ignore block called out specific reference files from a spike that has since been removed, and spent two comment lines describing them.

What is worth keeping is the general rule — binaries and archives do not belong in the repository — so `*.dll`, `*.exe` and `*.zip` stay under a one-line comment. The file-specific entries and the commentary go.

## Note

`*.wmz` was dropped along with them. It only ever covered the spike's reference material, and nothing in the project produces or consumes that format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
