### PR TITLE
Stop the media API route swallowing the icon font

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -21,6 +21,10 @@
           "builder": "@angular/build:application",
           "options": {
             "browser": "src/main.ts",
+            "outputPath": {
+              "base": "dist/onixlabs-media-player",
+              "media": "static"
+            },
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -34,7 +38,9 @@
               "src/styles.scss"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": ["src/styles"]
+              "includePaths": [
+                "src/styles"
+              ]
             }
           },
           "configurations": {
@@ -79,8 +85,12 @@
           "options": {
             "tsConfig": "tsconfig.spec.json",
             "runnerConfig": "vitest-base.config.ts",
-            "include": ["src/angular/**/*.spec.ts"],
-            "coverageInclude": ["src/angular/**/*.ts"],
+            "include": [
+              "src/angular/**/*.spec.ts"
+            ],
+            "coverageInclude": [
+              "src/angular/**/*.ts"
+            ],
             "coverageExclude": [
               "src/angular/**/*.spec.ts",
               "src/angular/**/*.d.ts",
@@ -88,7 +98,10 @@
               "src/angular/app.config.ts",
               "src/angular/app.routes.ts"
             ],
-            "coverageReporters": ["text-summary", "lcov"]
+            "coverageReporters": [
+              "text-summary",
+              "lcov"
+            ]
           },
           "configurations": {
             "coverage": {

--- a/src/electron/unified-media-server.spec.ts
+++ b/src/electron/unified-media-server.spec.ts
@@ -315,6 +315,28 @@ describe('UnifiedMediaServer', () => {
       expect(other.getAuthToken()).not.toBe(server.getAuthToken());
       expect(other.getAuthToken().length).toBeGreaterThanOrEqual(32);
     });
+
+    // A protected prefix shadows any static asset beneath it: the asset request
+    // carries no token and is answered with 401 instead of the file. A browser
+    // fetching a font from a stylesheet cannot attach a header, so this fails
+    // silently, and only once the bundle is served from here - which is to say
+    // only in a packaged build. Assert the build does not put assets anywhere
+    // an API prefix would swallow them.
+    it('does not emit build assets under a protected route prefix', () => {
+      const angularConfig: {projects: Record<string, {architect: {build: {options: {outputPath?: {media?: string}}}}}>} =
+        JSON.parse(fs.readFileSync(path.join(process.cwd(), 'angular.json'), 'utf-8'));
+      const mediaDir: string | undefined =
+        angularConfig.projects['onixlabs-media-player'].architect.build.options.outputPath?.media;
+
+      // Angular's default is 'media', which collides with the /media API.
+      expect(mediaDir).toBeDefined();
+      expect(mediaDir).not.toBe('media');
+
+      const assetPath: string = `/${mediaDir}/some-icon-font.woff2`;
+      for (const prefix of ['/events', '/media', '/player', '/playlist', '/settings', '/dependencies']) {
+        expect(assetPath === prefix || assetPath.startsWith(`${prefix}/`)).toBe(false);
+      }
+    });
   });
 
   // ==========================================================================

--- a/src/electron/unified-media-server.ts
+++ b/src/electron/unified-media-server.ts
@@ -171,6 +171,20 @@ export class UnifiedMediaServer {
    * IMPORTANT: adding a new API route under a new prefix requires adding the
    * prefix here, otherwise it will be served without authentication.
    */
+  /**
+   * GET prefixes that require the session token.
+   *
+   * These share a URL space with the Angular bundle this server also serves,
+   * and a prefix listed here shadows any static asset beneath it: the asset
+   * request carries no token, so it is answered with 401 rather than the file.
+   * A browser fetching a font or an image from a stylesheet cannot attach a
+   * header, so such an asset fails silently and only in packaged builds.
+   *
+   * That is why the build emits CSS-referenced resources to `static/` rather
+   * than Angular's default `media/`, which `/media` here would otherwise
+   * swallow. Anything added to this list needs the same check against the
+   * bundle's own paths.
+   */
   private static readonly API_ROUTE_PREFIXES: readonly string[] = [
     '/events',
     '/media',


### PR DESCRIPTION
## The bug

Installing the 2026.8.0 DMG gives a UI with **no icons at all** — play, stop, next, eject, everything.

## Cause

Angular's `application` builder emits resources referenced from CSS into `media/`, so the shipped stylesheet asks for:

```
/media/fa-solid-900-MDEYK55F.woff2
```

`#45` added a per-session token and listed `/media` among the protected API prefixes (it serves `/media/stream`, `/media/info`, `/media/url/*`). `isProtectedRequest` matches on prefix, so **every font request was treated as an API call**, arrived without an `X-Onix-Token` header, and was answered with **401**.

A browser fetching a font from a stylesheet cannot attach a custom header, so there was no way for it to succeed.

Three things made it hard to spot:

- **Packaged builds only.** This server only serves the Angular bundle in production; in development the dev server does, and it has no such route.
- **CSS and JS were fine.** They sit at `/styles-*.css` and `/main-*.js`, outside every protected prefix. Only the fonts live under `/media/`.
- **It failed silently.** No console error worth noticing — just a font that never arrives and glyphs that render as nothing.

## Fix

Emit those resources to `static/` instead, which no API prefix covers:

```json
"outputPath": { "base": "dist/onixlabs-media-player", "media": "static" }
```

Verified against a real build — fonts now land in `browser/static/` and the stylesheet references `./static/…`.

I fixed the collision rather than narrowing the route matcher, because `/media` is a legitimate API namespace that predates the bundle being served here, and loosening the matcher would trade a visible bug for a weaker fail-closed rule.

## Regression test

`unified-media-server.spec.ts` now asserts the build does not emit assets anywhere an API prefix would swallow them. Confirmed it fails when `media` is put back — `expected 'media' not to be 'media'` — so it is not a test that cannot fail.

The comment on `API_ROUTE_PREFIXES` now explains the hazard, so the next prefix added gets checked against the bundle's own paths.

## Follow-up

This wants a **2026.8.1** patch release; the published 2026.8.0 binaries all have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
