### PR TITLE
Release 2026.8.2

### DIFF
--- a/docs/releases/version-2026.8.2.md
+++ b/docs/releases/version-2026.8.2.md
@@ -1,0 +1,48 @@
+# ONIXPlayer 2026.8.2
+
+**Release Date:** August 2026
+**Platform:** macOS, Windows, Linux
+**Tech Stack:** Electron 43, Angular 21, TypeScript
+
+---
+
+## Overview
+
+A small release retuning the Ripple visualization.
+
+---
+
+## Changes
+
+### Ripple
+
+- **Three times the angular rate**, so the concentric rings travel outward rather than creeping
+- **More diffusion per step**, softening the field as it feeds itself
+- **The bass pulse is off** — a hit no longer sends a dark band out from the centre or takes the background white
+- **The horizontal trace deflects at about a third** of its previous amplitude, leaving it a band within the field rather than the loudest thing in it
+
+---
+
+## Downloads
+
+| Platform               | File                                     |
+| ---------------------- | ---------------------------------------- |
+| macOS (Apple Silicon)  | ONIXPlayer-2026.8.2-arm64.dmg            |
+| macOS (Intel)          | ONIXPlayer-2026.8.2-x64.dmg              |
+| macOS (Apple Silicon)  | ONIXPlayer-2026.8.2-arm64-mac.zip        |
+| macOS (Intel)          | ONIXPlayer-2026.8.2-x64-mac.zip          |
+| Windows                | ONIXPlayer Setup 2026.8.2.exe            |
+| Windows (portable)     | ONIXPlayer 2026.8.2.exe                  |
+| Linux (AppImage)       | ONIXPlayer-2026.8.2.AppImage             |
+| Linux (deb)            | onixlabs-media-player_2026.8.2_amd64.deb |
+
+---
+
+## Links
+
+- [GitHub Repository](https://github.com/onix-labs/onixlabs-media-player)
+- [ONIXLabs Website](https://onixlabs.io)
+
+---
+
+**License:** MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onixlabs-media-player",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onixlabs-media-player",
-      "version": "2026.8.1",
+      "version": "2026.8.2",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/common": "^21.2.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onixlabs-media-player",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "description": "Cross-platform media player with real-time audio visualizations, video playback, and MIDI synthesis",
   "author": {
     "name": "ONIXLabs",

--- a/src/angular/components/audio/audio-outlet/visualizations/ripple-visualization.ts
+++ b/src/angular/components/audio/audio-outlet/visualizations/ripple-visualization.ts
@@ -42,7 +42,7 @@ const RIPPLE_CATEGORY: string = 'Nostalgia';
 const RIPPLE_STOPS: readonly string[] = ['041028', '0E5A9E', '3FB8E8', 'BFF0FF', 'FFFFFF'];
 
 /** Angular rate, in radians per frame. The slowest turn in the suite. */
-const RATE_RIPPLE: number = -0.005;
+const RATE_RIPPLE: number = -0.015;
 
 /** Nominal surface height, matching the engine's own internal surface. */
 const NOMINAL_HEIGHT: number = 256;
@@ -61,7 +61,7 @@ const RADIAL_HEIGHT_BAND: number = 0.1;
 const RIPPLE_FLARE: number = 0.25;
 
 /** How much each pixel takes from its neighbours per step: the smoke. */
-const RIPPLE_DIFFUSE: number = 0.4;
+const RIPPLE_DIFFUSE: number = 0.5;
 
 /**
  * How far those neighbours sit, in pixels.
@@ -73,13 +73,13 @@ const RIPPLE_DIFFUSE: number = 0.4;
 const RIPPLE_DIFFUSE_REACH: number = 1;
 
 /** Ripple takes a bass hit as a cue to pulse. */
-const RIPPLE_PULSES: boolean = true;
+const RIPPLE_PULSES: boolean = false;
 
 /** Drawn before the warp, so the trace is folded outward with the surface. */
-const RIPPLE_PRE: readonly string[] = ['CircleWaveform 1 1 0.5 0'];
+const RIPPLE_PRE: readonly string[] = ['CircleWaveform 0 0 0.5 0'];
 
 /** Drawn after the warp: a soft glowing band about the waveform, not a stroke. */
-const RIPPLE_POST: readonly string[] = ['Trace 1 0 0 0'];
+const RIPPLE_POST: readonly string[] = ['Trace 0.3 0 0 0'];
 
 /** The spec the engine runs. */
 const RIPPLE_SPEC: FeedbackSpec = {


### PR DESCRIPTION
## Summary

Retunes **Ripple** and bumps the version to **2026.8.2**.

## Ripple

| Constant | Before | After | Effect |
| --- | --- | --- | --- |
| `RATE_RIPPLE` | `-0.005` | `-0.015` | Three times the angular rate — the rings travel rather than creep |
| `RIPPLE_DIFFUSE` | `0.4` | `0.5` | More smoke per step |
| `RIPPLE_PULSES` | `true` | `false` | A bass hit no longer sends a dark band out from the centre or whites the background |
| `RIPPLE_POST` | `Trace 1 …` | `Trace 0.3 …` | The horizontal trace deflects at about a third of its previous amplitude |
| `RIPPLE_PRE` | `CircleWaveform 1 1 0.5 0` | `CircleWaveform 0 0 0.5 0` | No effect — see below |

### One note on the `CircleWaveform` change

The first two parameters are now zero, but that makes no difference to what is drawn. `runRadial` in the feedback engine draws that generator as a full-screen pass and reads **only the third** parameter, the resting radius, which is unchanged at `0.5`:

```ts
const fraction: number = args[2] && args[2] > 0 ? args[2] : CIRCLE_FALLBACK_RADIUS;
```

Harmless either way, but flagging it in case something was intended by it. `Trace` does read its first two (`args[0]` scales amplitude, `args[1]` offsets the centre), which is why that one does have an effect.

## Release

Version bump plus `docs/releases/version-2026.8.2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
