### PR TITLE
Find Homebrew by absolute path so dependency actions work

### DIFF
--- a/src/electron/dependency-manager.spec.ts
+++ b/src/electron/dependency-manager.spec.ts
@@ -796,6 +796,131 @@ describe('DependencyManager', (): void => {
   });
 
   // ==========================================================================
+  // macOS Homebrew resolution
+  // ==========================================================================
+
+  describe('macOS Homebrew resolution', (): void => {
+    const BREW_ARM: string = '/opt/homebrew/bin/brew';
+    const BREW_INTEL: string = '/usr/local/bin/brew';
+
+    /**
+     * Mocks spawn with a child process that closes with the given exit code.
+     */
+    async function mockSpawnExiting(code: number): Promise<ReturnType<typeof vi.fn>> {
+      const { spawn } = await import('child_process');
+      const mockedSpawn: ReturnType<typeof vi.fn> = vi.mocked(spawn);
+      const mockProcess: {
+        stdout: { on: ReturnType<typeof vi.fn> };
+        stderr: { on: ReturnType<typeof vi.fn> };
+        on: ReturnType<typeof vi.fn>;
+      } = {
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, callback: (exitCode: number) => void): void => {
+          if (event === 'close') {
+            setTimeout((): void => callback(code), 0);
+          }
+        }),
+      };
+      mockedSpawn.mockReturnValue(mockProcess as ReturnType<typeof spawn>);
+      return mockedSpawn;
+    }
+
+    it('spawns brew by absolute path for install, not by bare name', async (): Promise<void> => {
+      setExistingPaths([BREW_INTEL]);
+      const mockedSpawn: ReturnType<typeof vi.fn> = await mockSpawnExiting(0);
+
+      const manager: DependencyManager = createManager('darwin');
+      await manager.installDependency('yt-dlp', vi.fn());
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        BREW_INTEL,
+        ['install', 'yt-dlp'],
+        expect.any(Object)
+      );
+    });
+
+    it('spawns brew by absolute path for uninstall', async (): Promise<void> => {
+      setExistingPaths([BREW_INTEL]);
+      const mockedSpawn: ReturnType<typeof vi.fn> = await mockSpawnExiting(0);
+
+      const manager: DependencyManager = createManager('darwin');
+      await manager.uninstallDependency('yt-dlp', vi.fn());
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        BREW_INTEL,
+        ['uninstall', 'yt-dlp'],
+        expect.any(Object)
+      );
+    });
+
+    it('spawns brew by absolute path for update', async (): Promise<void> => {
+      setExistingPaths([BREW_INTEL]);
+      const mockedSpawn: ReturnType<typeof vi.fn> = await mockSpawnExiting(0);
+
+      const manager: DependencyManager = createManager('darwin');
+      await manager.updateDependency('yt-dlp', vi.fn());
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        BREW_INTEL,
+        ['upgrade', 'yt-dlp'],
+        expect.any(Object)
+      );
+    });
+
+    it('prefers the Apple Silicon prefix over the Intel one', async (): Promise<void> => {
+      setExistingPaths([BREW_ARM, BREW_INTEL]);
+      const mockedSpawn: ReturnType<typeof vi.fn> = await mockSpawnExiting(0);
+
+      const manager: DependencyManager = createManager('darwin');
+      await manager.updateDependency('yt-dlp', vi.fn());
+
+      expect(mockedSpawn).toHaveBeenCalledWith(BREW_ARM, ['upgrade', 'yt-dlp'], expect.any(Object));
+    });
+
+    it('puts the Homebrew prefix on PATH for the spawned command', async (): Promise<void> => {
+      setExistingPaths([BREW_INTEL]);
+      const mockedSpawn: ReturnType<typeof vi.fn> = await mockSpawnExiting(0);
+
+      const manager: DependencyManager = createManager('darwin');
+      await manager.updateDependency('yt-dlp', vi.fn());
+
+      const options: { env: NodeJS.ProcessEnv } = mockedSpawn.mock.calls[0][2] as { env: NodeJS.ProcessEnv };
+      expect(options.env['PATH']?.split(path.delimiter)).toContain('/usr/local/bin');
+    });
+
+    it('reports a Homebrew install hint when brew is not found', async (): Promise<void> => {
+      mockedExistsSync.mockReturnValue(false);
+      const progressCalls: Array<{status: string; message: string}> = [];
+
+      const manager: DependencyManager = createManager('darwin');
+      const result: boolean = await manager.updateDependency('yt-dlp', (progress): void => {
+        progressCalls.push({status: progress.status, message: progress.message});
+      });
+
+      expect(result).toBe(false);
+      expect(progressCalls).toHaveLength(1);
+      expect(progressCalls[0].status).toBe('error');
+      expect(progressCalls[0].message).toContain('Homebrew');
+      expect(progressCalls[0].message).toContain('https://brew.sh');
+    });
+
+    it('reports a Homebrew install hint when uninstalling without brew', async (): Promise<void> => {
+      mockedExistsSync.mockReturnValue(false);
+      const progressCalls: Array<{status: string; message: string}> = [];
+
+      const manager: DependencyManager = createManager('darwin');
+      const result: boolean = await manager.uninstallDependency('yt-dlp', (progress): void => {
+        progressCalls.push({status: progress.status, message: progress.message});
+      });
+
+      expect(result).toBe(false);
+      expect(progressCalls[0].message).toContain('Cannot uninstall yt-dlp');
+      expect(progressCalls[0].message).toContain('Homebrew');
+    });
+  });
+
+  // ==========================================================================
   // Linux pkexec privilege elevation
   // ==========================================================================
 

--- a/src/electron/dependency-manager.ts
+++ b/src/electron/dependency-manager.ts
@@ -142,6 +142,21 @@ const SYSTEM_SOUNDFONT_PATHS: readonly string[] = [
 ];
 
 /**
+ * Absolute paths to the Homebrew binary, in preference order (Apple Silicon
+ * prefix first, then Intel).
+ *
+ * Homebrew cannot be spawned as a bare `brew`. A macOS app launched from Finder
+ * inherits launchd's PATH — `/usr/bin:/bin:/usr/sbin:/sbin` — which contains
+ * neither prefix, so the spawn fails with ENOENT before the package manager
+ * ever runs. Only a run started from a terminal, inheriting the shell's PATH,
+ * ever found it.
+ */
+const HOMEBREW_PATHS: readonly string[] = [
+  '/opt/homebrew/bin/brew',  // Apple Silicon
+  '/usr/local/bin/brew',     // Intel
+];
+
+/**
  * Windows-specific constants for Chocolatey package manager.
  */
 const CHOCOLATEY_WINGET_ID: string = 'Chocolatey.Chocolatey';
@@ -548,7 +563,7 @@ export class DependencyManager {
 
     const cmd: {command: string; args: string[]} | null = this.getUpdateCommand(id);
     if (!cmd) {
-      const errorMsg: string = this.getPackageManagerErrorMessage(id, 'install');
+      const errorMsg: string = this.getPackageManagerErrorMessage(id, 'update');
       depsLogger.error(errorMsg);
       onProgress({dependencyId: id, status: 'error', message: errorMsg});
       return false;
@@ -821,7 +836,7 @@ export class DependencyManager {
 
     switch (this.platform) {
       case 'darwin':
-        return {command: 'brew', args: ['install', packageName]};
+        return this.getBrewCommand(['install', packageName]);
 
       case 'linux':
         return this.getLinuxInstallCommand(id);
@@ -844,7 +859,7 @@ export class DependencyManager {
 
     switch (this.platform) {
       case 'darwin':
-        return {command: 'brew', args: ['uninstall', packageName]};
+        return this.getBrewCommand(['uninstall', packageName]);
 
       case 'linux':
         return this.getLinuxUninstallCommand(id);
@@ -870,7 +885,7 @@ export class DependencyManager {
 
     switch (this.platform) {
       case 'darwin':
-        return {command: 'brew', args: ['upgrade', packageName]};
+        return this.getBrewCommand(['upgrade', packageName]);
 
       case 'linux':
         // Re-running the install command upgrades to the latest available version.
@@ -958,6 +973,31 @@ export class DependencyManager {
   }
 
   /**
+   * Finds the Homebrew binary by absolute path.
+   *
+   * @returns Absolute path to brew, or null if Homebrew is not installed
+   */
+  private findBrew(): string | null {
+    for (const p of HOMEBREW_PATHS) {
+      if (existsSync(p)) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Builds a Homebrew command with the binary resolved to an absolute path.
+   *
+   * @param args - Arguments to pass to brew (e.g. ['install', 'yt-dlp'])
+   * @returns Command and args, or null if Homebrew is not installed
+   */
+  private getBrewCommand(args: string[]): {command: string; args: string[]} | null {
+    const brew: string | null = this.findBrew();
+    return brew ? {command: brew, args} : null;
+  }
+
+  /**
    * Checks if Chocolatey is available on the system.
    */
   private isChocoAvailable(): boolean {
@@ -985,7 +1025,13 @@ export class DependencyManager {
   /**
    * Gets a helpful error message when no package manager is available.
    */
-  private getPackageManagerErrorMessage(id: DependencyId, operation: 'install' | 'uninstall'): string {
+  private getPackageManagerErrorMessage(id: DependencyId, operation: 'install' | 'uninstall' | 'update'): string {
+    // macOS: everything goes through Homebrew
+    if (this.platform === 'darwin' && !this.findBrew()) {
+      return `Cannot ${operation} ${DEPENDENCY_NAMES[id]}: Homebrew is required but was not found. ` +
+        'Install Homebrew from https://brew.sh, or use the Manual Download link.';
+    }
+
     // Windows: FFmpeg requires winget
     if (this.platform === 'win32' && id === 'ffmpeg' && !this.isWingetAvailable()) {
       return `Cannot ${operation} FFmpeg: winget (Windows Package Manager) is required but not installed. ` +
@@ -1003,7 +1049,7 @@ export class DependencyManager {
       const pkgMgr: 'apt' | 'dnf' | 'pacman' | null = this.detectLinuxPackageManager();
       if (pkgMgr && !this.isPkexecAvailable()) {
         return `Cannot ${operation} ${DEPENDENCY_NAMES[id]}: pkexec is required for graphical authentication. ` +
-          `Please install via terminal: sudo ${pkgMgr} ${operation === 'install' ? 'install' : 'remove'} -y ${this.getPackageName(id)}`;
+          `Please install via terminal: sudo ${pkgMgr} ${operation === 'uninstall' ? 'remove' : 'install'} -y ${this.getPackageName(id)}`;
       }
     }
 
@@ -1108,6 +1154,40 @@ export class DependencyManager {
   }
 
   /**
+   * Builds the environment for a package manager run, putting the manager's own
+   * directory on PATH.
+   *
+   * Resolving the binary absolutely is enough to start it, but not enough for
+   * what it starts in turn: Homebrew shells out to its own prefix, and under
+   * launchd's PATH those lookups would miss for the same reason the `brew`
+   * lookup did.
+   *
+   * Left alone on Windows, where a GUI process already inherits the user's full
+   * environment and `process.env` is case-insensitive in a way that spreading it
+   * into a new object would break.
+   *
+   * @param command - The command about to be spawned
+   * @returns Environment for the child process
+   */
+  private getCommandEnv(command: string): NodeJS.ProcessEnv {
+    if (this.platform === 'win32' || !path.isAbsolute(command)) {
+      return process.env;
+    }
+
+    const dir: string = path.dirname(command);
+    const currentPath: string = process.env['PATH'] ?? '';
+
+    if (currentPath.split(path.delimiter).includes(dir)) {
+      return process.env;
+    }
+
+    return {
+      ...process.env,
+      PATH: currentPath ? `${dir}${path.delimiter}${currentPath}` : dir,
+    };
+  }
+
+  /**
    * Runs a command and streams output via the progress callback.
    * Re-detects binaries after completion.
    *
@@ -1133,6 +1213,7 @@ export class DependencyManager {
 
       const child: ChildProcess = spawn(command, args, {
         stdio: ['pipe', 'pipe', 'pipe'],
+        env: this.getCommandEnv(command),
       });
 
       let outputBuffer: string = '';


### PR DESCRIPTION
## Problem

Install, Update and Uninstall for Homebrew-managed dependencies all failed on macOS. From the app log:

```
[Deps] Uninstalling yt-dlp...
[Deps] Failed to run brew: spawn brew ENOENT
[Deps] brew exited with code -2
[Deps] yt-dlp uninstalling failed (exit code -2)
```

A GUI app launched from Finder inherits launchd's `PATH` — `/usr/bin:/bin:/usr/sbin:/sbin` — which contains neither Homebrew prefix. `spawn` does a bare-name `PATH` lookup with no shell, so `brew` was never found and the package manager never ran. Only a run started from a terminal, inheriting the shell's `PATH`, ever worked.

This surfaced as "yt-dlp cannot be Updated or Uninstalled", but Install was broken identically — it was just never hit, because the dependency was already installed and the UI only offered Update and Uninstall.

## Fix

- `HOMEBREW_PATHS` / `findBrew()` / `getBrewCommand()` — resolve `brew` to an absolute path (Apple Silicon prefix first, then Intel) before spawning. Used by install, uninstall and update on darwin.
- `getCommandEnv()` — put the Homebrew prefix on the child's `PATH`. Starting brew is not enough on its own: brew shells out to its own prefix, and those lookups would miss for the same reason the `brew` lookup did. Left alone on Windows, where a GUI process already inherits the user's full environment.

## Also fixed alongside

- `updateDependency` passed `'install'` to `getPackageManagerErrorMessage`, so a missing package manager produced the wrong hint.
- `getPackageManagerErrorMessage` had no macOS branch — a missing Homebrew surfaced as `No package manager found for darwin` rather than pointing at https://brew.sh.
- The Linux hint suggested `install` when the failed operation was an update.

## Tests

Adds a `macOS Homebrew resolution` suite covering: absolute-path spawn for install/uninstall/update, Apple Silicon prefix preference when both exist, the Homebrew prefix landing on the child's `PATH`, and the "Homebrew not found" error message for both update and uninstall.

## Known gaps (not addressed here)

- `HOMEBREW_PATHS` prefers `/opt/homebrew` unconditionally. On a machine with both prefixes, it would pick the ARM brew while a keg lives under `/usr/local/Cellar`, and uninstall would fail with `No such keg`.
- `findBinary` accepts `/usr/bin/<binary>`, but uninstall/update always go through brew — a pipx/pip-installed yt-dlp would show as installed, then fail on `brew uninstall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)