### PR TITLE
Ask where to save before a URL download

### DIFF
--- a/context.md
+++ b/context.md
@@ -471,10 +471,11 @@ Based on independent review with all 31 action items resolved:
 │  │  └─────────────┘  └─────────────┘  └─────────────┘               │ │
 │  └───────────────────────────────────────────────────────────────────┘ │
 │                                                                         │
-│  IPC (minimal - 22 channels):                                          │
+│  IPC (minimal - 23 channels):                                          │
 │  ├── dialog:openFile         (native file picker)                      │
 │  ├── dialog:openPlaylist     (playlist file picker for .opp files)     │
 │  ├── dialog:savePlaylist     (save dialog for .opp files)              │
+│  ├── dialog:saveMedia        (save dialog for a URL download)          │
 │  ├── dialog:openSubtitle     (subtitle file picker for .srt/.vtt/.ass) │
 │  ├── dialog:openSoundFont    (SoundFont file picker)                   │
 │  ├── app:getServerPort       (get HTTP server port)                    │

--- a/src/angular/components/open-url-dialog/open-url-dialog.html
+++ b/src/angular/components/open-url-dialog/open-url-dialog.html
@@ -90,7 +90,7 @@
           </div>
           <p class="url-mode-hint">
             @if (mode() === 'download') {
-              Downloads the file first, then plays it — fully seekable and works offline afterwards.
+              Asks where to save, downloads the file, then plays it — fully seekable and works offline afterwards.
             } @else {
               Plays directly from the source without saving. Faster to start; may be less reliable.
             }

--- a/src/angular/components/open-url-dialog/open-url-dialog.scss
+++ b/src/angular/components/open-url-dialog/open-url-dialog.scss
@@ -219,13 +219,16 @@
 .url-progress-bar {
   flex: 1;
   height: 0.5rem;
-  border-radius: 2px;
+  border-radius: 9999px;
   background: var(--text-10);
   overflow: hidden;
 }
 
 .url-progress-fill {
   height: 100%;
+  // Matches the track so the leading edge stays rounded as the fill grows;
+  // the track's overflow clip alone would square it off at 0%.
+  border-radius: 9999px;
   background: $color-success;
   transition: width 0.2s ease;
 }

--- a/src/angular/components/open-url-dialog/open-url-dialog.spec.ts
+++ b/src/angular/components/open-url-dialog/open-url-dialog.spec.ts
@@ -4,7 +4,8 @@
  * Tests cover:
  * - fetchInfo success, failure and the re-entry guard
  * - Quality defaulting to the highest available format
- * - submit() in both stream and download modes, including failure handling
+ * - submit() in both stream and download modes, including the Save As dialog
+ *   that precedes a download, and failure handling
  * - The effect that reacts to the active download job completing or failing
  * - Cancellation and the small form setters
  *
@@ -67,6 +68,7 @@ function createMockElectron(): Record<string, unknown> {
     downloadJob: signal<DownloadJob | null>(null),
     getUrlInfo: vi.fn().mockResolvedValue(createInfo()),
     streamUrl: vi.fn().mockResolvedValue(undefined),
+    saveMediaDialog: vi.fn().mockResolvedValue('/chosen/A Video.mp4'),
     downloadUrl: vi.fn().mockResolvedValue({jobId: 'job-1'}),
     cancelDownload: vi.fn().mockResolvedValue(undefined),
     setContentHeight: vi.fn().mockResolvedValue(undefined),
@@ -329,13 +331,35 @@ describe('OpenUrlDialog', (): void => {
       expect(component.activeJobId()).toBe('job-1');
     });
 
+    it('asks where to save before downloading', async (): Promise<void> => {
+      await component.submit();
+
+      expect(mockElectron['saveMediaDialog']).toHaveBeenCalledWith('A Video', 'video');
+    });
+
+    it('offers an mp3 destination for audio', async (): Promise<void> => {
+      component.mediaFormat.set('audio');
+
+      await component.submit();
+
+      expect(mockElectron['saveMediaDialog']).toHaveBeenCalledWith('A Video', 'audio');
+    });
+
+    it('downloads to the chosen path', async (): Promise<void> => {
+      await component.submit();
+
+      expect(mockElectron['downloadUrl']).toHaveBeenCalledWith(
+        'https://example.com/v', 'video', 'fmt-1080', 'A Video', '/chosen/A Video.mp4'
+      );
+    });
+
     it('passes the selected format id for video', async (): Promise<void> => {
       component.selectedFormatId.set('fmt-720');
 
       await component.submit();
 
       expect(mockElectron['downloadUrl']).toHaveBeenCalledWith(
-        'https://example.com/v', 'video', 'fmt-720', 'A Video'
+        'https://example.com/v', 'video', 'fmt-720', 'A Video', '/chosen/A Video.mp4'
       );
     });
 
@@ -346,8 +370,29 @@ describe('OpenUrlDialog', (): void => {
       await component.submit();
 
       expect(mockElectron['downloadUrl']).toHaveBeenCalledWith(
-        'https://example.com/v', 'audio', null, 'A Video'
+        'https://example.com/v', 'audio', null, 'A Video', '/chosen/A Video.mp4'
       );
+    });
+
+    it('starts nothing when the save dialog is cancelled', async (): Promise<void> => {
+      (mockElectron['saveMediaDialog'] as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await component.submit();
+
+      expect(mockElectron['downloadUrl']).not.toHaveBeenCalled();
+      expect(component.submitting()).toBe(false);
+      expect(component.error()).toBeNull();
+    });
+
+    it('can be retried after the save dialog was cancelled', async (): Promise<void> => {
+      const saveDialog = mockElectron['saveMediaDialog'] as ReturnType<typeof vi.fn>;
+      saveDialog.mockResolvedValueOnce(null);
+
+      await component.submit();
+      await component.submit();
+
+      expect(mockElectron['downloadUrl']).toHaveBeenCalledTimes(1);
+      expect(component.activeJobId()).toBe('job-1');
     });
 
     it('stays submitting while the job runs', async (): Promise<void> => {

--- a/src/angular/components/open-url-dialog/open-url-dialog.ts
+++ b/src/angular/components/open-url-dialog/open-url-dialog.ts
@@ -4,7 +4,8 @@
  * This is the renderer-side counterpart to the yt-dlp backend (the
  * TypeScript port of ReClip). The user pastes a URL, the dialog resolves
  * its metadata and quality options, and then either:
- * - downloads the media to a local file (default — robust, fully seekable), or
+ * - asks where to save via the native Save As dialog and downloads the media
+ *   there before playing it (robust, fully seekable), or
  * - resolves a direct stream URL and plays it immediately (opt-in).
  *
  * Both paths feed the resolved file/URL into the existing playlist pipeline
@@ -207,8 +208,16 @@ export class OpenUrlDialog implements AfterViewInit, OnDestroy {
         this.close();
         return;
       }
+      const title: string = this.info()?.title ?? '';
+      // Ask where to save before spawning yt-dlp: a cancelled dialog should
+      // leave the form exactly as it was, with nothing downloaded.
+      const outputPath: string | null = await this.electron.saveMediaDialog(title, format);
+      if (!outputPath) {
+        this.submitting.set(false);
+        return;
+      }
       const formatId: string | null = format === 'video' ? this.selectedFormatId() : null;
-      const result: {jobId: string} = await this.electron.downloadUrl(value, format, formatId, this.info()?.title ?? '');
+      const result: {jobId: string} = await this.electron.downloadUrl(value, format, formatId, title, outputPath);
       this.activeJobId.set(result.jobId);
       // Completion/error handled by the effect watching downloadJob.
     } catch (err: unknown) {

--- a/src/angular/services/electron.service.spec.ts
+++ b/src/angular/services/electron.service.spec.ts
@@ -117,6 +117,7 @@ const mockApi: {
   clearRecentItems: ReturnType<typeof vi.fn>;
   openPlaylistDialog: ReturnType<typeof vi.fn>;
   savePlaylistDialog: ReturnType<typeof vi.fn>;
+  saveMediaDialog: ReturnType<typeof vi.fn>;
   openSubtitleDialog: ReturnType<typeof vi.fn>;
   setupGetPort: ReturnType<typeof vi.fn>;
   setupSetPort: ReturnType<typeof vi.fn>;
@@ -163,6 +164,7 @@ const mockApi: {
   clearRecentItems: vi.fn().mockResolvedValue(undefined),
   openPlaylistDialog: vi.fn().mockResolvedValue(null),
   savePlaylistDialog: vi.fn().mockResolvedValue(null),
+  saveMediaDialog: vi.fn().mockResolvedValue(null),
   openSubtitleDialog: vi.fn().mockResolvedValue(null),
   setupGetPort: vi.fn().mockResolvedValue(0),
   setupSetPort: vi.fn().mockResolvedValue(undefined),

--- a/src/angular/services/electron.service.ts
+++ b/src/angular/services/electron.service.ts
@@ -1540,11 +1540,13 @@ export class ElectronService implements OnDestroy {
    * @param format - 'video' (MP4) or 'audio' (MP3)
    * @param formatId - Optional yt-dlp format id for a chosen resolution
    * @param title - Optional title used to name the downloaded file
+   * @param outputPath - Destination chosen in {@link saveMediaDialog}, which the
+   *   finished file is moved to
    * @returns The created job id
    */
-  public async downloadUrl(url: string, format: UrlMediaFormat, formatId: string | null, title: string): Promise<{jobId: string}> {
+  public async downloadUrl(url: string, format: UrlMediaFormat, formatId: string | null, title: string, outputPath: string): Promise<{jobId: string}> {
     this.downloadJob.set(null);
-    return this.postExpectingMessage<{jobId: string}>('/media/url/download', {url, format, formatId, title});
+    return this.postExpectingMessage<{jobId: string}>('/media/url/download', {url, format, formatId, title, outputPath});
   }
 
   /**
@@ -1677,6 +1679,19 @@ export class ElectronService implements OnDestroy {
   public async savePlaylistDialog(): Promise<string | null> {
     if (!this.isElectron || !this.api) return null;
     return this.api.savePlaylistDialog();
+  }
+
+  /**
+   * Opens a native save dialog for a media file about to be downloaded from a
+   * URL, letting the user choose where it is written before yt-dlp starts.
+   *
+   * @param title - Media title, offered as the suggested filename
+   * @param format - 'video' (suggests .mp4) or 'audio' (suggests .mp3)
+   * @returns Promise resolving to the chosen file path, or null if cancelled
+   */
+  public async saveMediaDialog(title: string, format: UrlMediaFormat): Promise<string | null> {
+    if (!this.isElectron || !this.api) return null;
+    return this.api.saveMediaDialog({title, format});
   }
 
   /**

--- a/src/angular/types/electron.d.ts
+++ b/src/angular/types/electron.d.ts
@@ -48,6 +48,27 @@ export interface OpenDialogOptions {
 }
 
 /**
+ * Configuration options for the native save dialog shown before a URL download.
+ *
+ * Passed through IPC to Electron's dialog.showSaveDialog(). The main process
+ * sanitizes the title into a legal filename and appends the extension implied
+ * by the format, so the renderer only has to supply the raw media metadata.
+ *
+ * @example
+ * const options: SaveMediaDialogOptions = {
+ *   title: 'Some Video Title',
+ *   format: 'video'
+ * };
+ */
+export interface SaveMediaDialogOptions {
+  /** Media title, offered to the user as the suggested filename. */
+  title: string;
+
+  /** Requested output format; 'video' suggests .mp4 and 'audio' suggests .mp3. */
+  format: 'video' | 'audio';
+}
+
+/**
  * Represents a subtitle track embedded in a media file.
  *
  * Subtitle tracks are detected via FFprobe and can be extracted
@@ -444,6 +465,14 @@ export interface MediaPlayerAPI {
    * @returns Promise resolving to the chosen file path, or null if cancelled
    */
   savePlaylistDialog: () => Promise<string | null>;
+
+  /**
+   * Opens a native save dialog for a media file about to be downloaded from a
+   * URL, so the user picks the destination before the download starts.
+   * @param options - Suggested filename and requested output format
+   * @returns Promise resolving to the chosen file path, or null if cancelled
+   */
+  saveMediaDialog: (options: SaveMediaDialogOptions) => Promise<string | null>;
 
   /**
    * Opens a native dialog to select an external subtitle file (.srt, .vtt, .ass, .ssa).

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -38,6 +38,21 @@ const AUDIO_EXTENSIONS: readonly string[] = ['mp3', 'flac', 'wav', 'ogg', 'm4a',
 const VIDEO_EXTENSIONS: readonly string[] = ['mp4', 'm4v', 'mkv', 'avi', 'webm', 'mov'];
 
 /**
+ * Characters that are illegal in filenames on at least one supported platform.
+ * Stripped from a media title before it is offered as a save-dialog filename.
+ */
+const ILLEGAL_FILENAME_CHARS: RegExp = /[\\/:*?"<>|]/g;
+
+/**
+ * Maximum length of a filename suggested in the media save dialog. Long video
+ * titles otherwise produce names that some filesystems reject outright.
+ */
+const MAX_SUGGESTED_FILENAME_LENGTH: number = 80;
+
+/** Filename offered when a media title is empty or sanitizes away to nothing. */
+const FALLBACK_MEDIA_FILENAME: string = 'download';
+
+/**
  * Files passed to the app before it was ready.
  * These are queued and processed after the window is created.
  */
@@ -1239,6 +1254,45 @@ class Program {
       }
 
       ipcLogger.info(`dialog:savePlaylist - selected: ${result.filePath}`);
+      return result.filePath;
+    });
+
+    // Save downloaded media dialog - asked by the Open URL window before a
+    // yt-dlp download starts, so the user picks where the file lands.
+    ipcMain.handle("dialog:saveMedia", async (event: Readonly<Electron.IpcMainInvokeEvent>, options: Readonly<{
+      title: string;
+      format: 'video' | 'audio';
+    }>): Promise<string | null> => {
+      ipcLogger.debug(`dialog:saveMedia - format=${options.format}`);
+
+      // Parent on the window that asked (the Open URL window), so the dialog
+      // is attached to what the user is looking at rather than the player.
+      const parent: BrowserWindow | null = BrowserWindow.fromWebContents(event.sender) ?? this.window;
+      if (!parent) {
+        ipcLogger.warn('dialog:saveMedia - no window available');
+        return null;
+      }
+
+      const isAudio: boolean = options.format === 'audio';
+      const extension: string = isAudio ? 'mp3' : 'mp4';
+      const suggestedName: string = options.title
+        .replace(ILLEGAL_FILENAME_CHARS, '')
+        .trim()
+        .slice(0, MAX_SUGGESTED_FILENAME_LENGTH)
+        .trim() || FALLBACK_MEDIA_FILENAME;
+
+      const result: Electron.SaveDialogReturnValue = await dialog.showSaveDialog(parent, {
+        title: 'Save Media As',
+        defaultPath: `${suggestedName}.${extension}`,
+        filters: [{name: isAudio ? 'MP3 Audio' : 'MP4 Video', extensions: [extension]}],
+      });
+
+      if (result.canceled || !result.filePath) {
+        ipcLogger.info('dialog:saveMedia - cancelled');
+        return null;
+      }
+
+      ipcLogger.info(`dialog:saveMedia - selected: ${result.filePath}`);
       return result.filePath;
     });
 

--- a/src/electron/media-download-manager.spec.ts
+++ b/src/electron/media-download-manager.spec.ts
@@ -659,11 +659,18 @@ describe('MediaDownloadManager', (): void => {
   // ==========================================================================
 
   describe('moving to a chosen output path', (): void => {
-    const OUTPUT_PATH: string = '/Users/someone/Movies/Chosen.mp4';
+    // Built with path.join so the separators match the host platform: these
+    // paths are compared against ones the manager itself joined.
+    const OUTPUT_PATH: string = path.join(DOWNLOADS_DIR, '..', 'chosen', 'Movie.mp4');
     let child: FakeChild;
+    /** yt-dlp output template for the run, set by finishWithOutputPath. */
+    let stagedTemplate: string;
+    /** Path the finished file was staged at, set by finishWithOutputPath. */
+    let stagedPath: string;
 
     /**
-     * Runs a completed download that was given an output path.
+     * Runs a completed download that was given an output path, recording the
+     * staging paths the manager derived for it.
      *
      * @returns The finished job
      */
@@ -671,22 +678,24 @@ describe('MediaDownloadManager', (): void => {
       child = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
       const id: string = manager.startDownload('https://example.com/v', 'video', null, 'My Video', OUTPUT_PATH, vi.fn());
+      stagedTemplate = path.join(DOWNLOADS_DIR, `${id}.%(ext)s`);
+      stagedPath = path.join(DOWNLOADS_DIR, `${id}.mp4`);
       vi.mocked(readdirSync).mockReturnValue([`${id}.mp4`] as unknown as ReturnType<typeof readdirSync>);
       child.emitClose(0);
       return manager.getJob(id);
     }
 
-    it('still stages the download in the downloads directory', (): void => {
+    it('stages the download rather than handing the chosen path to yt-dlp', (): void => {
       finishWithOutputPath();
 
-      expect(lastSpawnArgs().join(' ')).toContain(DOWNLOADS_DIR);
+      expect(lastSpawnArgs()).toContain(stagedTemplate);
       expect(lastSpawnArgs()).not.toContain(OUTPUT_PATH);
     });
 
     it('moves the finished file to the chosen path', (): void => {
       const job: DownloadJob | undefined = finishWithOutputPath();
 
-      expect(renameSync).toHaveBeenCalledWith(expect.stringContaining(DOWNLOADS_DIR), OUTPUT_PATH);
+      expect(renameSync).toHaveBeenCalledWith(stagedPath, OUTPUT_PATH);
       expect(job?.filePath).toBe(OUTPUT_PATH);
     });
 
@@ -703,8 +712,8 @@ describe('MediaDownloadManager', (): void => {
 
       const job: DownloadJob | undefined = finishWithOutputPath();
 
-      expect(copyFileSync).toHaveBeenCalledWith(expect.stringContaining(DOWNLOADS_DIR), OUTPUT_PATH);
-      expect(unlinkSync).toHaveBeenCalled();
+      expect(copyFileSync).toHaveBeenCalledWith(stagedPath, OUTPUT_PATH);
+      expect(unlinkSync).toHaveBeenCalledWith(stagedPath);
       expect(job?.filePath).toBe(OUTPUT_PATH);
     });
 
@@ -719,7 +728,23 @@ describe('MediaDownloadManager', (): void => {
       const job: DownloadJob | undefined = finishWithOutputPath();
 
       expect(job?.status).toBe('done');
-      expect(job?.filePath).toContain(DOWNLOADS_DIR);
+      expect(job?.filePath).toBe(stagedPath);
+    });
+
+    it('keeps the staged file when the failure is not an Error', (): void => {
+      // fs throws plain strings in some runtimes; the warning must not blow up
+      // reaching for .message on something that has none.
+      vi.mocked(renameSync).mockImplementationOnce((): never => {
+        throw 'EXDEV';
+      });
+      vi.mocked(copyFileSync).mockImplementationOnce((): never => {
+        throw 'ENOSPC';
+      });
+
+      const job: DownloadJob | undefined = finishWithOutputPath();
+
+      expect(job?.status).toBe('done');
+      expect(job?.filePath).toBe(stagedPath);
     });
   });
 

--- a/src/electron/media-download-manager.spec.ts
+++ b/src/electron/media-download-manager.spec.ts
@@ -6,7 +6,8 @@
  * - buildFormats de-duplication, filtering and ordering
  * - startDownload argument construction, including the `--` terminator
  * - Progress parsing, failure paths and the stderr tail used as the message
- * - finalizeDownload file selection and title renaming
+ * - finalizeDownload file selection, title renaming, and the move to a
+ *   caller-supplied output path (the Save As destination)
  * - cancelDownload status guards
  * - resolveStreamSources selector construction and DASH-pair splitting
  *
@@ -18,10 +19,12 @@
 // ============================================================================
 
 vi.mock('fs', () => ({
+  copyFileSync: vi.fn(),
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
   readdirSync: vi.fn(),
   renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
 }));
 
 vi.mock('child_process', () => ({
@@ -49,7 +52,7 @@ vi.mock('./logger.js', () => ({
 // Imports (after mocks)
 // ============================================================================
 
-import { existsSync, readdirSync, renameSync } from 'fs';
+import { copyFileSync, existsSync, readdirSync, renameSync, unlinkSync } from 'fs';
 import { spawn, execFile } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import * as path from 'path';
@@ -177,7 +180,7 @@ describe('MediaDownloadManager', (): void => {
     });
 
     it('fails a download job for a file:// URL rather than spawning', (): void => {
-      const id: string = manager.startDownload('file:///etc/passwd', 'video', null, 'x', vi.fn());
+      const id: string = manager.startDownload('file:///etc/passwd', 'video', null, 'x', null, vi.fn());
 
       expect(spawn).not.toHaveBeenCalled();
       expect(manager.getJob(id)?.errorMessage).toMatch(/only http and https/i);
@@ -214,7 +217,7 @@ describe('MediaDownloadManager', (): void => {
       const hostile: string = 'https://example.com/-nasty';
       vi.mocked(spawn).mockReturnValue(createFakeChild());
 
-      manager.startDownload(hostile, 'video', null, 'T', vi.fn());
+      manager.startDownload(hostile, 'video', null, 'T', null, vi.fn());
 
       const args: string[] = lastSpawnArgs();
       expect(args[args.indexOf(hostile) - 1]).toBe('--');
@@ -368,14 +371,14 @@ describe('MediaDownloadManager', (): void => {
       ytdlpPath = null;
       const onUpdate = vi.fn();
 
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', onUpdate);
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', null, onUpdate);
 
       expect(manager.getJob(id)).toMatchObject({status: 'error', errorMessage: 'yt-dlp is not installed'});
       expect(spawn).not.toHaveBeenCalled();
     });
 
     it('terminates option parsing before the URL', (): void => {
-      manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       const args: string[] = lastSpawnArgs();
       expect(args[args.length - 2]).toBe('--');
@@ -383,7 +386,7 @@ describe('MediaDownloadManager', (): void => {
     });
 
     it('extracts audio as mp3 in audio mode', (): void => {
-      manager.startDownload('https://example.com/v', 'audio', null, 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'audio', null, 'T', null, vi.fn());
 
       const args: string[] = lastSpawnArgs();
       expect(args).toContain('-x');
@@ -391,19 +394,19 @@ describe('MediaDownloadManager', (): void => {
     });
 
     it('requests a specific format id when given one', (): void => {
-      manager.startDownload('https://example.com/v', 'video', '137', 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'video', '137', 'T', null, vi.fn());
 
       expect(lastSpawnArgs().join(' ')).toContain('-f 137+bestaudio/best');
     });
 
     it('falls back to the best pair when no format id is given', (): void => {
-      manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       expect(lastSpawnArgs().join(' ')).toContain('-f bestvideo+bestaudio/best');
     });
 
     it('passes the ffmpeg location when ffmpeg is installed', (): void => {
-      manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       expect(lastSpawnArgs().join(' ')).toContain('--ffmpeg-location /usr/bin/ffmpeg');
     });
@@ -411,13 +414,13 @@ describe('MediaDownloadManager', (): void => {
     it('omits the ffmpeg location when ffmpeg is missing', (): void => {
       ffmpegPath = null;
 
-      manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       expect(lastSpawnArgs()).not.toContain('--ffmpeg-location');
     });
 
     it('writes into the downloads directory using the job id', (): void => {
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       expect(lastSpawnArgs().join(' ')).toContain(path.join(DOWNLOADS_DIR, `${id}.%(ext)s`));
     });
@@ -425,14 +428,14 @@ describe('MediaDownloadManager', (): void => {
     it('reports the job as downloading straight away', (): void => {
       const onUpdate = vi.fn();
 
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', onUpdate);
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', null, onUpdate);
 
       expect(onUpdate).toHaveBeenCalled();
       expect(manager.getJob(id)?.status).toBe('downloading');
     });
 
     it('trims the supplied title', (): void => {
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, '  Spaced  ', vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, '  Spaced  ', null, vi.fn());
 
       expect(manager.getJob(id)?.title).toBe('Spaced');
     });
@@ -451,7 +454,7 @@ describe('MediaDownloadManager', (): void => {
       child = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
       onUpdate = vi.fn();
-      id = manager.startDownload('https://example.com/v', 'video', null, 'T', onUpdate);
+      id = manager.startDownload('https://example.com/v', 'video', null, 'T', null, onUpdate);
     });
 
     it('parses a percentage into a 0..1 fraction', (): void => {
@@ -520,7 +523,7 @@ describe('MediaDownloadManager', (): void => {
     function start(format: 'audio' | 'video', title: string): string {
       child = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
-      return manager.startDownload('https://example.com/v', format, null, title, vi.fn());
+      return manager.startDownload('https://example.com/v', format, null, title, null, vi.fn());
     }
 
     it('fails when no file was produced', (): void => {
@@ -598,7 +601,7 @@ describe('MediaDownloadManager', (): void => {
     function finishWithTitle(title: string, targetExists: boolean = false): DownloadJob | undefined {
       child = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, title, vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, title, null, vi.fn());
       vi.mocked(readdirSync).mockReturnValue([`${id}.mp4`] as unknown as ReturnType<typeof readdirSync>);
       // The constructor's directory check already ran; only the rename target matters now.
       vi.mocked(existsSync).mockReturnValue(targetExists);
@@ -652,6 +655,75 @@ describe('MediaDownloadManager', (): void => {
   });
 
   // ==========================================================================
+  // moveToChosenPath (via finalize)
+  // ==========================================================================
+
+  describe('moving to a chosen output path', (): void => {
+    const OUTPUT_PATH: string = '/Users/someone/Movies/Chosen.mp4';
+    let child: FakeChild;
+
+    /**
+     * Runs a completed download that was given an output path.
+     *
+     * @returns The finished job
+     */
+    function finishWithOutputPath(): DownloadJob | undefined {
+      child = createFakeChild();
+      vi.mocked(spawn).mockReturnValue(child);
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'My Video', OUTPUT_PATH, vi.fn());
+      vi.mocked(readdirSync).mockReturnValue([`${id}.mp4`] as unknown as ReturnType<typeof readdirSync>);
+      child.emitClose(0);
+      return manager.getJob(id);
+    }
+
+    it('still stages the download in the downloads directory', (): void => {
+      finishWithOutputPath();
+
+      expect(lastSpawnArgs().join(' ')).toContain(DOWNLOADS_DIR);
+      expect(lastSpawnArgs()).not.toContain(OUTPUT_PATH);
+    });
+
+    it('moves the finished file to the chosen path', (): void => {
+      const job: DownloadJob | undefined = finishWithOutputPath();
+
+      expect(renameSync).toHaveBeenCalledWith(expect.stringContaining(DOWNLOADS_DIR), OUTPUT_PATH);
+      expect(job?.filePath).toBe(OUTPUT_PATH);
+    });
+
+    it('does not rename to the title when a path was chosen', (): void => {
+      const job: DownloadJob | undefined = finishWithOutputPath();
+
+      expect(job?.filePath).not.toContain('My Video');
+    });
+
+    it('falls back to copy-and-delete across volumes', (): void => {
+      vi.mocked(renameSync).mockImplementationOnce((): never => {
+        throw new Error('EXDEV: cross-device link not permitted');
+      });
+
+      const job: DownloadJob | undefined = finishWithOutputPath();
+
+      expect(copyFileSync).toHaveBeenCalledWith(expect.stringContaining(DOWNLOADS_DIR), OUTPUT_PATH);
+      expect(unlinkSync).toHaveBeenCalled();
+      expect(job?.filePath).toBe(OUTPUT_PATH);
+    });
+
+    it('keeps the staged file when the move cannot be completed', (): void => {
+      vi.mocked(renameSync).mockImplementationOnce((): never => {
+        throw new Error('EXDEV');
+      });
+      vi.mocked(copyFileSync).mockImplementationOnce((): never => {
+        throw new Error('ENOSPC');
+      });
+
+      const job: DownloadJob | undefined = finishWithOutputPath();
+
+      expect(job?.status).toBe('done');
+      expect(job?.filePath).toContain(DOWNLOADS_DIR);
+    });
+  });
+
+  // ==========================================================================
   // cancelDownload
   // ==========================================================================
 
@@ -659,7 +731,7 @@ describe('MediaDownloadManager', (): void => {
     it('kills the process and marks the job cancelled', (): void => {
       const child: FakeChild = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
 
       expect(manager.cancelDownload(id)).toBe(true);
       expect(child.kill).toHaveBeenCalledWith('SIGKILL');
@@ -673,7 +745,7 @@ describe('MediaDownloadManager', (): void => {
     it('returns false for a job that is already finished', (): void => {
       const child: FakeChild = createFakeChild();
       vi.mocked(spawn).mockReturnValue(child);
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, '', vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, '', null, vi.fn());
       vi.mocked(readdirSync).mockReturnValue([`${id}.mp4`] as unknown as ReturnType<typeof readdirSync>);
       child.emitClose(0);
 
@@ -682,7 +754,7 @@ describe('MediaDownloadManager', (): void => {
 
     it('returns false when cancelled twice', (): void => {
       vi.mocked(spawn).mockReturnValue(createFakeChild());
-      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', vi.fn());
+      const id: string = manager.startDownload('https://example.com/v', 'video', null, 'T', null, vi.fn());
       manager.cancelDownload(id);
 
       expect(manager.cancelDownload(id)).toBe(false);

--- a/src/electron/media-download-manager.ts
+++ b/src/electron/media-download-manager.ts
@@ -17,7 +17,7 @@
 
 import {spawn, ChildProcess, execFile} from 'child_process';
 import {randomUUID} from 'crypto';
-import {existsSync, mkdirSync, readdirSync, renameSync} from 'fs';
+import {copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, unlinkSync} from 'fs';
 import * as path from 'path';
 import {createScopedLogger, logProcessSpawn, logProcessExit} from './logger.js';
 import type {UrlMediaInfo, UrlFormat, UrlMediaFormat, DownloadJob} from './media-types.js';
@@ -245,13 +245,19 @@ export class MediaDownloadManager {
    * Starts an asynchronous download of a URL to a local file.
    *
    * The returned job is tracked in memory; callers poll {@link getJob} or react
-   * to the supplied progress callback. On success the job's `filePath` points to
-   * the finished file, renamed to a sanitized title where possible.
+   * to the supplied progress callback. yt-dlp always writes into the downloads
+   * directory first, because the final extension is only known once the merge
+   * or audio extraction has run. On success the finished file is moved to
+   * `outputPath` when the caller chose one (the Save As dialog), and otherwise
+   * renamed to a sanitized title in place; either way the job's `filePath`
+   * points at the file that playback should use.
    *
    * @param url - The page URL to download
    * @param format - 'video' (MP4) or 'audio' (MP3 extraction)
    * @param formatId - Optional yt-dlp format id for a specific video resolution
    * @param title - Optional title used to name the resulting file
+   * @param outputPath - Absolute path the finished file is moved to, or null to
+   *   leave it in the downloads directory under its sanitized title
    * @param onUpdate - Called whenever the job's status or progress changes
    * @returns The newly created job's id
    */
@@ -260,6 +266,7 @@ export class MediaDownloadManager {
     format: UrlMediaFormat,
     formatId: string | null,
     title: string,
+    outputPath: string | null,
     onUpdate: (job: Readonly<DownloadJob>) => void
   ): string {
     const id: string = randomUUID().slice(0, 12);
@@ -339,7 +346,7 @@ export class MediaDownloadManager {
         this.failJob(job, this.lastErrorLine(stderrTail) || `yt-dlp exited with code ${code}`, onUpdate);
         return;
       }
-      this.finalizeDownload(job, onUpdate);
+      this.finalizeDownload(job, outputPath, onUpdate);
     });
 
     child.on('error', (error: Readonly<Error>): void => {
@@ -352,10 +359,15 @@ export class MediaDownloadManager {
   }
 
   /**
-   * Locates the finished file, renames it to a sanitized title, and marks the
-   * job done. Called once yt-dlp exits successfully.
+   * Locates the finished file, moves it to its final home, and marks the job
+   * done. Called once yt-dlp exits successfully.
+   *
+   * @param job - The job being finalized
+   * @param outputPath - Destination chosen by the user, or null to keep the
+   *   file in the downloads directory under a sanitized title
+   * @param onUpdate - Called with the finished (or failed) job
    */
-  private finalizeDownload(job: DownloadJob, onUpdate: (job: Readonly<DownloadJob>) => void): void {
+  private finalizeDownload(job: DownloadJob, outputPath: string | null, onUpdate: (job: Readonly<DownloadJob>) => void): void {
     const produced: string[] = readdirSync(this.downloadsDir)
       .filter((name: string): boolean => name.startsWith(`${job.id}.`))
       .map((name: string): string => path.join(this.downloadsDir, name));
@@ -369,7 +381,7 @@ export class MediaDownloadManager {
     const preferredExt: string = job.format === 'audio' ? '.mp3' : '.mp4';
     const chosen: string = produced.find((f: string): boolean => f.toLowerCase().endsWith(preferredExt)) ?? produced[0];
 
-    job.filePath = this.renameToTitle(chosen, job.title);
+    job.filePath = outputPath ? this.moveToChosenPath(chosen, outputPath) : this.renameToTitle(chosen, job.title);
     job.progress = 1;
     job.status = 'done';
     downloadLogger.info(`Download complete: ${path.basename(job.filePath)}`);
@@ -396,6 +408,35 @@ export class MediaDownloadManager {
     } catch (error: unknown) {
       downloadLogger.warn(`Could not rename download to title: ${error instanceof Error ? error.message : error}`);
       return filePath;
+    }
+  }
+
+  /**
+   * Moves a finished download to the path the user picked in the Save As
+   * dialog. Overwriting is intentional: the dialog already asked.
+   *
+   * A plain rename fails across devices, and the downloads directory often sits
+   * on a different volume from the user's chosen destination (an external disk,
+   * a network share), so fall back to copy-then-delete. If even that fails the
+   * staged path is returned so playback still gets a usable file.
+   *
+   * @param filePath - The staged file in the downloads directory
+   * @param outputPath - Absolute destination path chosen by the user
+   * @returns The destination path, or the staged path if the move failed
+   */
+  private moveToChosenPath(filePath: string, outputPath: string): string {
+    try {
+      renameSync(filePath, outputPath);
+      return outputPath;
+    } catch {
+      try {
+        copyFileSync(filePath, outputPath);
+        unlinkSync(filePath);
+        return outputPath;
+      } catch (error: unknown) {
+        downloadLogger.warn(`Could not move download to ${outputPath}: ${error instanceof Error ? error.message : error}`);
+        return filePath;
+      }
     }
   }
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -33,6 +33,19 @@ export interface OpenDialogOptions {
 }
 
 /**
+ * Options for the native save dialog shown before a URL download starts.
+ *
+ * @property title - Media title, offered as the filename after sanitizing
+ * @property format - Requested output, which picks the .mp4/.mp3 extension
+ */
+export interface SaveMediaDialogOptions {
+  /** Media title used as the suggested filename */
+  readonly title: string;
+  /** Requested output format, determining the suggested extension */
+  readonly format: 'video' | 'audio';
+}
+
+/**
  * API exposed to the renderer process via window.mediaPlayer.
  *
  * This interface defines the complete set of functionality available to the
@@ -73,6 +86,15 @@ export interface MediaPlayerAPI {
    * @returns Promise resolving to the chosen file path, or null if cancelled
    */
   readonly savePlaylistDialog: () => Promise<string | null>;
+
+  /**
+   * Opens a native save dialog for a media file about to be downloaded from a
+   * URL, so the user chooses the destination before yt-dlp starts.
+   *
+   * @param options - Suggested filename and requested output format
+   * @returns Promise resolving to the chosen file path, or null if cancelled
+   */
+  readonly saveMediaDialog: (options: Readonly<SaveMediaDialogOptions>) => Promise<string | null>;
 
   /**
    * Opens a native dialog to select an external subtitle file.
@@ -444,6 +466,7 @@ const api: MediaPlayerAPI = {
   openFileDialog: (options: Readonly<OpenDialogOptions>): Promise<string[]> => ipcRenderer.invoke('dialog:openFile', options),
   openPlaylistDialog: (): Promise<string | null> => ipcRenderer.invoke('dialog:openPlaylist'),
   savePlaylistDialog: (): Promise<string | null> => ipcRenderer.invoke('dialog:savePlaylist'),
+  saveMediaDialog: (options: Readonly<SaveMediaDialogOptions>): Promise<string | null> => ipcRenderer.invoke('dialog:saveMedia', options),
   openSubtitleDialog: (): Promise<string | null> => ipcRenderer.invoke('dialog:openSubtitle'),
   openSoundFontDialog: (): Promise<string[]> => ipcRenderer.invoke('dialog:openSoundFont'),
   getPathForFile: (file: Readonly<File>): string => webUtils.getPathForFile(file),

--- a/src/electron/unified-media-server.ts
+++ b/src/electron/unified-media-server.ts
@@ -2477,13 +2477,16 @@ export class UnifiedMediaServer {
   /**
    * Handles POST /media/url/download — starts a background download of a URL.
    *
-   * Body: { url: string, format?: 'video'|'audio', formatId?: string, title?: string }
+   * Body: { url: string, format?: 'video'|'audio', formatId?: string, title?: string,
+   *         outputPath?: string }
+   * `outputPath` is the destination the user picked in the native Save As
+   * dialog; when omitted the file stays in the downloads directory.
    * Returns the job id immediately; progress, completion, and errors are
    * broadcast over SSE (download:progress / download:complete / download:error).
    */
   private async handleUrlDownload(req: Readonly<IncomingMessage>, res: Readonly<ServerResponse>): Promise<void> {
     const body: string = await this.readBody(req);
-    const { url, format, formatId, title }: { url?: unknown; format?: unknown; formatId?: unknown; title?: unknown } = JSON.parse(body);
+    const { url, format, formatId, title, outputPath }: { url?: unknown; format?: unknown; formatId?: unknown; title?: unknown; outputPath?: unknown } = JSON.parse(body);
     if (typeof url !== 'string' || !url.trim()) {
       res.writeHead(400);
       res.end(JSON.stringify({ error: 'No URL provided' }));
@@ -2496,6 +2499,7 @@ export class UnifiedMediaServer {
       mediaFormat,
       typeof formatId === 'string' ? formatId : null,
       typeof title === 'string' ? title : '',
+      typeof outputPath === 'string' && outputPath.trim() ? outputPath : null,
       (job: Readonly<DownloadJob>): void => this.broadcastDownloadUpdate(job)
     );
 


### PR DESCRIPTION
## Summary

"Download & Play" in the Open URL window previously wrote into the app's downloads directory under a sanitized title, giving the user no say in where the file landed. It now opens the native **Save As** dialog first, downloads to the chosen path, and plays from there once finished.

Also rounds the download progress bar into a pill.

## Design notes

**Staging is deliberate.** yt-dlp still writes into the downloads directory as `<jobId>.%(ext)s`; the finished file is moved to the chosen path in `finalizeDownload`. Pointing `-o` straight at the destination would be fragile — the real extension is only known after the merge/audio-extraction step, so staging keeps the existing container-selection logic intact.

**The move has a cross-volume fallback.** `renameSync` falls back to `copyFileSync` + `unlinkSync`, because the downloads directory and the user's destination are often on different volumes, where rename fails with `EXDEV`. If both fail, the staged path is returned so playback still gets a usable file.

**The new `dialog:saveMedia` handler parents on the invoking window** (`BrowserWindow.fromWebContents(event.sender)`) rather than `this.window` like the other dialog handlers, so it sheets onto the Open URL window the user is actually looking at.

Cancelling the save dialog starts nothing and leaves the form as it was. The existing `download:complete` SSE handler already adds the finished file to the playlist and auto-plays, so the "play once downloaded" half needed no change.

## Changes

- `src/electron/main.ts` — new `dialog:saveMedia` IPC handler; sanitizes the title into a legal filename and suggests `.mp4`/`.mp3`
- `src/electron/preload.ts`, `src/angular/types/electron.d.ts` — `saveMediaDialog` + `SaveMediaDialogOptions`
- `src/angular/services/electron.service.ts` — `saveMediaDialog()`; `downloadUrl()` gains a required `outputPath`
- `src/electron/unified-media-server.ts` — `/media/url/download` accepts optional `outputPath`
- `src/electron/media-download-manager.ts` — `startDownload` gains `outputPath: string | null`; `moveToChosenPath` added
- `src/angular/components/open-url-dialog/` — save dialog precedes the download; pill progress bar
- `context.md` — IPC channel inventory

## Testing

Specs updated: 18 `startDownload` call sites, new fs mocks (`copyFileSync`/`unlinkSync`), plus cases for the move, the cross-volume fallback, and save-dialog cancellation.

**Not verified by me** — build, typecheck, and test runs are outstanding, as is manual confirmation of the dialog in the real app.

## Note for review

While the native dialog is open, `submitting()` is already true, so the footer briefly reads "Cancel Download" with a "Starting…" progress bar behind the sheet. It's unreachable (the dialog is window-modal), but it could be gated on a separate signal if you'd rather the UI not flip until a path is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)